### PR TITLE
Fix: add missing comma in MultiPL-E languages

### DIFF
--- a/bigcode_eval/tasks/multiple.py
+++ b/bigcode_eval/tasks/multiple.py
@@ -53,7 +53,7 @@ LANGUAGES = [
     "js",
     "jl",
     "lua",
-    "ml"
+    "ml",
     "pl",
     "php",
     "r",


### PR DESCRIPTION
This builds on #299 by adding a missing comma in another location.